### PR TITLE
Godot 3.2 Tile Map changes

### DIFF
--- a/addons/vnen.tiled_importer/tiled_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_import_plugin.gd
@@ -111,7 +111,7 @@ func import(source_file, save_path, options, r_platform_variants, r_gen_files):
 	var map_reader = TiledMapReader.new()
 
 	# Offset is only optional for importing TileSets
-	options.apply_offset = true
+	options.apply_offset = false
 	var scene = map_reader.build(source_file, options)
 
 	if typeof(scene) != TYPE_OBJECT:


### PR DESCRIPTION
3.2 changed how tile maps work.  The Y offset is not needed when working with 3.2.